### PR TITLE
Sticky footer added

### DIFF
--- a/app/javascript/css/application.css
+++ b/app/javascript/css/application.css
@@ -1,5 +1,14 @@
 @import "picnic/picnic.min.css";
 
+html, body {
+    height: 100%;
+}
+
+body {
+    display: flex;
+    flex-direction: column;
+}
+
 .wrapper > section {
     text-align: left;
     margin: 0;
@@ -17,4 +26,12 @@ footer{
 
 nav .menu>* {
     display: inline;
+}
+
+.wrapper {
+    flex: 1 0 auto;
+  }
+
+footer {
+    flex-shrink: 0;
 }


### PR DESCRIPTION
Added sticky footer by using css flex property. To make footer always stick at the bottom of the page, html and body is given relative height of 100%. 

![screen shot 2018-10-02 at 15 30 10](https://user-images.githubusercontent.com/1160546/46351626-19f97280-c658-11e8-99b2-c1596d3c39bf.png)
